### PR TITLE
Fix non-deterministic error messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,6 @@ All user visible changes to this project will be documented in this file. This p
 
 
 
-
 ## [0.1.2] · ???
 [0.1.2]: /../../tree/v0.1.2
 
@@ -17,6 +16,7 @@ All user visible changes to this project will be documented in this file. This p
 - Non-deterministic error messages. ([#2])
 
 [#2]: /../../pull/2
+
 
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ All user visible changes to this project will be documented in this file. This p
 
 
 
+
+## [0.1.2] · ???
+[0.1.2]: /../../tree/v0.1.2
+
+[Diff](/../../compare/v0.1.1...v0.1.2)
+
+### Fixed
+
+- Non-deterministic error messages. ([#2])
+
+[#2]: /../../pull/2
+
+
+
 ## [0.1.1] · 2021-08-13
 [0.1.1]: /../../tree/v0.1.1
 

--- a/core/src/codegen/parse_attrs.rs
+++ b/core/src/codegen/parse_attrs.rs
@@ -1,6 +1,6 @@
 //! `#[derive(ParseAttrs)]` proc macro implementation.
 
-use std::{collections::HashSet, convert::TryFrom, iter};
+use std::{collections::BTreeSet, convert::TryFrom, iter};
 
 use proc_macro2::{Span, TokenStream};
 use quote::{quote, ToTokens};
@@ -300,16 +300,12 @@ impl TryFrom<syn::Field> for Field {
         };
         names.try_merge_self::<kind::Value, dedup::Unique>(attrs.aliases)?;
 
-        let mut names =
-            names.into_iter().map(|n| n.to_string()).collect::<Vec<String>>();
-        names.sort();
-
         Ok(Self {
             ident,
             ty: field.ty,
             kind: **attrs.kind,
             dedup: attrs.dedup.as_deref().copied().unwrap_or_default(),
-            names,
+            names: names.into_iter().map(|n| n.to_string()).collect(),
             validators: attrs.validators,
             fallbacks: attrs.fallbacks,
         })
@@ -418,12 +414,12 @@ struct FieldAttrs {
     /// Names of [`syn::Attribute`]'s arguments to use for parsing __instead
     /// of__ the [`ParseAttrs`]'s field's [`syn::Ident`].
     // #[parse(value, alias = arg)]
-    args: HashSet<syn::Ident>,
+    args: BTreeSet<syn::Ident>,
 
     /// Names of [`syn::Attribute`]'s arguments to use for parsing __along
     /// with__ the [`ParseAttrs`]'s field's [`syn::Ident`].
     // #[parse(value, alias = alias)]
-    aliases: HashSet<syn::Ident>,
+    aliases: BTreeSet<syn::Ident>,
 
     /// [`dedup`]lication strategy of how multiple values of the
     /// [`ParseAttrs`]'s field should be merged.

--- a/core/src/codegen/parse_attrs.rs
+++ b/core/src/codegen/parse_attrs.rs
@@ -300,12 +300,16 @@ impl TryFrom<syn::Field> for Field {
         };
         names.try_merge_self::<kind::Value, dedup::Unique>(attrs.aliases)?;
 
+        let mut names =
+            names.into_iter().map(|n| n.to_string()).collect::<Vec<String>>();
+        names.sort();
+
         Ok(Self {
             ident,
             ty: field.ty,
             kind: **attrs.kind,
             dedup: attrs.dedup.as_deref().copied().unwrap_or_default(),
-            names: names.into_iter().map(|n| n.to_string()).collect(),
+            names,
             validators: attrs.validators,
             fallbacks: attrs.fallbacks,
         })

--- a/tests/parse_attrs.rs
+++ b/tests/parse_attrs.rs
@@ -615,6 +615,54 @@ mod value {
         }
     }
 
+    mod required_aliased {
+        use synthez::Required;
+
+        use super::*;
+
+        #[derive(Debug, Default, ParseAttrs)]
+        struct Attr {
+            #[parse(value, alias = required)]
+            name: Required<syn::Ident>,
+        }
+
+        #[test]
+        fn allows_present() {
+            let input: syn::DeriveInput = syn::parse_quote! {
+                #[attr(name = minas)]
+                struct Dummy;
+            };
+
+            let res = Attr::parse_attrs("attr", &input);
+            assert!(res.is_ok(), "failed: {}", res.unwrap_err());
+
+            assert_eq!(
+                *res.unwrap().name,
+                syn::Ident::new_on_call_site("minas"),
+            );
+        }
+
+        #[test]
+        fn forbids_absent() {
+            let input: syn::DeriveInput = syn::parse_quote! {
+                struct Dummy;
+            };
+
+            let res = Attr::parse_attrs("attr", &input);
+            assert!(res.is_err(), "should fail, but is ok");
+
+            let err = res.unwrap_err().to_string();
+            assert!(
+                err.contains(
+                    "either `name` or `required` argument of `#[attr]` \
+                     attribute is expected to be present, but is absent",
+                ),
+                "wrong err:\n{}",
+                err,
+            );
+        }
+    }
+
     mod required_fallback {
         use synthez::{field, Required};
 

--- a/tests/parse_attrs.rs
+++ b/tests/parse_attrs.rs
@@ -643,6 +643,22 @@ mod value {
         }
 
         #[test]
+        fn allows_alias() {
+            let input: syn::DeriveInput = syn::parse_quote! {
+                #[attr(required = tirith)]
+                struct Dummy;
+            };
+
+            let res = Attr::parse_attrs("attr", &input);
+            assert!(res.is_ok(), "failed: {}", res.unwrap_err());
+
+            assert_eq!(
+                *res.unwrap().name,
+                syn::Ident::new_on_call_site("tirith"),
+            );
+        }
+
+        #[test]
         fn forbids_absent() {
             let input: syn::DeriveInput = syn::parse_quote! {
                 struct Dummy;


### PR DESCRIPTION
## Synopsis

As described [here](https://github.com/arcana-rs/arcana/pull/2#discussion_r695452795) error messages are non-deterministic. 




## Solution

Sort `names` field after converting it from `HashSet<syn::Ident>`.




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains `Draft: ` prefix
    - [x] Name contains issue reference
    - [x] Has `k::` labels applied
    - [x] Has assignee
- [x] Documentation is updated (if required)
- [x] Tests are updated (if required)
- [x] Changes conform code style
- [x] CHANGELOG entry is added (if required)
- [x] FCM (final commit message) is posted
    - [x] and approved
- [x] [Review][l:2] is completed and changes are approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] `Draft: ` prefix is removed
    - [x] All temporary labels are removed





[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
